### PR TITLE
ゲームオーバーでスコア集計する機能追加

### DIFF
--- a/GFF2026A/Assets/Prefabs/Animals/Lion.prefab
+++ b/GFF2026A/Assets/Prefabs/Animals/Lion.prefab
@@ -43,6 +43,7 @@ GameObject:
   - component: {fileID: 4065987499015118909}
   - component: {fileID: 7171468690936085040}
   - component: {fileID: -7475932546753612042}
+  - component: {fileID: 372605552000769480}
   m_Layer: 0
   m_Name: Lion
   m_TagString: Untagged
@@ -106,6 +107,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6ad769700a666de4d9f9f78fc8b7595f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &372605552000769480
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4515878626337536649}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bcf98a837af434a4da740ead8f5f5ee1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  data: {fileID: 11400000, guid: 3a190d49e7210474390fbba3e5a0f4c2, type: 2}
 --- !u!1 &6141965711868501440
 GameObject:
   m_ObjectHideFlags: 0

--- a/GFF2026A/Assets/Prefabs/Animals/Panda.prefab
+++ b/GFF2026A/Assets/Prefabs/Animals/Panda.prefab
@@ -185,6 +185,7 @@ GameObject:
   - component: {fileID: 4065987499015118909}
   - component: {fileID: 1476143421221543726}
   - component: {fileID: 4937808689755197720}
+  - component: {fileID: 963882195248947800}
   m_Layer: 0
   m_Name: Panda
   m_TagString: Untagged
@@ -248,6 +249,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6ad769700a666de4d9f9f78fc8b7595f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &963882195248947800
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4515878626337536649}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bcf98a837af434a4da740ead8f5f5ee1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  data: {fileID: 11400000, guid: 7a670d5f039a39b459c905d700767367, type: 2}
 --- !u!1 &9103964236409980795
 GameObject:
   m_ObjectHideFlags: 0

--- a/GFF2026A/Assets/Scenes/InGame.unity
+++ b/GFF2026A/Assets/Scenes/InGame.unity
@@ -180,7 +180,7 @@ BoxCollider2D:
   m_CallbackLayers:
     serializedVersion: 2
     m_Bits: 4294967295
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
@@ -533,6 +533,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 430837082}
+  - {fileID: 1468821148}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -540,6 +541,11 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!224 &1468821148 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4492957250354078298, guid: e36797810a311e24b94925db63c2511a, type: 3}
+  m_PrefabInstance: {fileID: 1615779827}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1536208021
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -689,6 +695,111 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 08844ec4bfb3ea346a43921841f18586, type: 3}
+--- !u!1001 &1615779827
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1308027955}
+    m_Modifications:
+    - target: {fileID: 2901244487256387869, guid: e36797810a311e24b94925db63c2511a, type: 3}
+      propertyPath: m_sharedMaterial
+      value: 
+      objectReference: {fileID: 7345424045541795890, guid: 90f985075e9482b44ac1e15d789a37d3, type: 2}
+    - target: {fileID: 2901244487256387869, guid: e36797810a311e24b94925db63c2511a, type: 3}
+      propertyPath: m_hasFontAssetChanged
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4492957250354078298, guid: e36797810a311e24b94925db63c2511a, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4492957250354078298, guid: e36797810a311e24b94925db63c2511a, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4492957250354078298, guid: e36797810a311e24b94925db63c2511a, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4492957250354078298, guid: e36797810a311e24b94925db63c2511a, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4492957250354078298, guid: e36797810a311e24b94925db63c2511a, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4492957250354078298, guid: e36797810a311e24b94925db63c2511a, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4492957250354078298, guid: e36797810a311e24b94925db63c2511a, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 200
+      objectReference: {fileID: 0}
+    - target: {fileID: 4492957250354078298, guid: e36797810a311e24b94925db63c2511a, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 4492957250354078298, guid: e36797810a311e24b94925db63c2511a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4492957250354078298, guid: e36797810a311e24b94925db63c2511a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4492957250354078298, guid: e36797810a311e24b94925db63c2511a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4492957250354078298, guid: e36797810a311e24b94925db63c2511a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4492957250354078298, guid: e36797810a311e24b94925db63c2511a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4492957250354078298, guid: e36797810a311e24b94925db63c2511a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4492957250354078298, guid: e36797810a311e24b94925db63c2511a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4492957250354078298, guid: e36797810a311e24b94925db63c2511a, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4492957250354078298, guid: e36797810a311e24b94925db63c2511a, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -100
+      objectReference: {fileID: 0}
+    - target: {fileID: 4492957250354078298, guid: e36797810a311e24b94925db63c2511a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4492957250354078298, guid: e36797810a311e24b94925db63c2511a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4492957250354078298, guid: e36797810a311e24b94925db63c2511a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4818443232188523870, guid: e36797810a311e24b94925db63c2511a, type: 3}
+      propertyPath: m_Name
+      value: Time
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e36797810a311e24b94925db63c2511a, type: 3}
 --- !u!1 &1725322470
 GameObject:
   m_ObjectHideFlags: 0

--- a/GFF2026A/Assets/Scripts/Manager/AnimalManager.cs
+++ b/GFF2026A/Assets/Scripts/Manager/AnimalManager.cs
@@ -14,6 +14,7 @@ public class AnimalManager : MonoBehaviour, IAnimalRegistry
     public static AnimalManager Instance { get; private set; }
 
     public IReadOnlyList<GameObject> Registered => gameObjects;
+    public event Action<int> OnScoreRecalculated; // スコア集計完了時に通知
     private void Awake()
     {
         if (Instance != null && Instance != this) { Destroy(gameObject); return; }
@@ -70,5 +71,28 @@ public class AnimalManager : MonoBehaviour, IAnimalRegistry
             yield return new WaitForSeconds(destroyInterval);
         }
         gameObjects.Clear();
+    }
+
+    // ===== 全動物のスコア集計 =====
+    public int CalculateTotalScore()
+    {
+        int total = 0;
+        foreach (var go in gameObjects)
+        {
+            if (!go) continue;
+            var providers = go.GetComponentsInChildren<AnimalScoreProvider>();
+            foreach (var p in providers)
+            {
+                total += p.GetScore();
+            }
+        }
+        return total;
+    }
+
+    public int RecalculateAndNotify()
+    {
+        int total = CalculateTotalScore();
+        OnScoreRecalculated?.Invoke(total);
+        return total;
     }
 }

--- a/GFF2026A/Assets/Scripts/Manager/GameOverController.cs
+++ b/GFF2026A/Assets/Scripts/Manager/GameOverController.cs
@@ -24,8 +24,12 @@ public class GameOverController : MonoBehaviour
     bool _isGameOver;
     float _sinceLastSpawn; // 直近の生成からの経過時間
 
+    public static GameOverController Instance { get; private set; }
+
     void Awake()
     {
+        if (Instance != null && Instance != this) { Destroy(gameObject); return; }
+        Instance = this;
         if (!animalManager) animalManager = AnimalManager.Instance;
         if (!mainCamera) mainCamera = Camera.main;
     }
@@ -43,6 +47,12 @@ public class GameOverController : MonoBehaviour
 
     void Update()
     {
+        //デバッグ
+        if (Input.GetKeyDown(KeyCode.R))
+        {
+            GameOver();
+        }
+
         if (_isGameOver) return;
 
         _timer += Time.deltaTime;
@@ -64,7 +74,7 @@ public class GameOverController : MonoBehaviour
             if (!go) continue;
             if (go.transform.position.y < failY)
             {
-                TriggerGameOver();
+                TriggerReset();
                 break;
             }
         }
@@ -76,13 +86,18 @@ public class GameOverController : MonoBehaviour
         _sinceLastSpawn = 0f;
     }
 
-    public void TriggerGameOver()
+    public void TriggerReset()
+    {
+        ResetGame();
+    }
+
+    public void GameOver()
     {
         if (_isGameOver) return;
         _isGameOver = true;
 
-        // ここで演出（SFX/画面フラッシュ/文字）を出してもOK
-        ResetGame();
+        int totalScore = AnimalManager.Instance.CalculateTotalScore();
+        Debug.Log($"ゲームオーバー！ スコア：{totalScore}");
     }
 
     void ResetGame()

--- a/GFF2026A/Assets/Scripts/Manager/KillZone2D.cs
+++ b/GFF2026A/Assets/Scripts/Manager/KillZone2D.cs
@@ -9,6 +9,6 @@ public class KillZone2D : MonoBehaviour
         // AnimalPiece だけ対象にしたいならフィルタ
         if (!other.GetComponentInParent<AnimalPiece>()) return;
 
-        gameOver?.TriggerGameOver(); // publicにしておく
+        gameOver?.TriggerReset(); // publicにしておく
     }
 }

--- a/GFF2026A/Assets/Scripts/Score.meta
+++ b/GFF2026A/Assets/Scripts/Score.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3bc4272ae0ac129429cf14c440fc31bf
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/GFF2026A/Assets/Scripts/Score/AnimalScoreProvider.cs
+++ b/GFF2026A/Assets/Scripts/Score/AnimalScoreProvider.cs
@@ -1,0 +1,7 @@
+using UnityEngine;
+
+public class AnimalScoreProvider : MonoBehaviour
+{
+    [SerializeField] private AnimalData data;
+    public int GetScore() => data ? data.ScoreValue : 0;
+}

--- a/GFF2026A/Assets/Scripts/Score/AnimalScoreProvider.cs.meta
+++ b/GFF2026A/Assets/Scripts/Score/AnimalScoreProvider.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bcf98a837af434a4da740ead8f5f5ee1

--- a/GFF2026A/Assets/Scripts/Score/IScoreProvider.cs
+++ b/GFF2026A/Assets/Scripts/Score/IScoreProvider.cs
@@ -1,0 +1,4 @@
+public interface IScoreProvider
+{
+    int GetScore();
+}

--- a/GFF2026A/Assets/Scripts/Score/IScoreProvider.cs.meta
+++ b/GFF2026A/Assets/Scripts/Score/IScoreProvider.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8e8192dcd72305247905ec93971a5ad7

--- a/GFF2026A/Assets/Scripts/UI/CountdownUI.cs
+++ b/GFF2026A/Assets/Scripts/UI/CountdownUI.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 public class CountdownUI : MonoBehaviour
 {
     // 現在の時間
-    private float currentTime = 120;
+    private float currentTime = 30;
 
     // テキストの参照
     private TextMeshProUGUI timeText;
@@ -21,7 +21,11 @@ public class CountdownUI : MonoBehaviour
         if (currentTime > 0)
         {
             currentTime -= Time.deltaTime;
-            if (currentTime < 0) currentTime = 0;
+            if (currentTime < 0)
+            {
+                currentTime = 0;
+                GameOverController.Instance.GameOver();
+            }
         }
         // 分と秒に変換して表示
         int totalSeconds = Mathf.FloorToInt(currentTime);

--- a/GFF2026A/ProjectSettings/EditorBuildSettings.asset
+++ b/GFF2026A/ProjectSettings/EditorBuildSettings.asset
@@ -5,9 +5,18 @@ EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Scenes:
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/SampleScene.unity
     guid: 8c9cfa26abfee488c85f1582747f6a02
+  - enabled: 1
+    path: Assets/Scenes/Title.unity
+    guid: d9935743f4473ec4ea8fdb59bc0ada6e
+  - enabled: 1
+    path: Assets/Scenes/InGame.unity
+    guid: 240d40134ec8ed44890636256edbfcff
+  - enabled: 1
+    path: Assets/Scenes/Result.unity
+    guid: e481427a4cb949c43ac2713a66c3fcd6
   m_configObjects:
     com.unity.input.settings.actions: {fileID: -944628639613478452, guid: 2bcd2660ca9b64942af0de543d8d7100, type: 3}
   m_UseUCBPForAssetBundles: 0


### PR DESCRIPTION
## 概要
スコア集計機能追加

## 対応内容
- プレハブにスコアを読み取れる機能追加
- AnimalManagerにスコア集計機能追加
- CountdownUIにカウントダウン終了時ゲームオーバーする機能追加
- ゲームオーバー時、スコア集計してデバッグログに出す機能追加

## テスト
- [x] ゲーム終了時、スコア集計されること

## 備考